### PR TITLE
Refactor createPaseoClient to auto-create pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ npm run build
 ```ts
 import { createPaseoClient } from "paseo-sdk";
 
-const paseo = createPaseoClient("https://your-paseo-endpoint.paseo.workers.dev");
-
-await paseo.usePod("my-entity");
+const paseo = await createPaseoClient();
 
 const reply = await paseo.sendPrompt("What's the current state of this entity?");
 console.log("🤖", reply);
@@ -58,9 +56,13 @@ console.log("🧠", history);
 
 ## 🧰 API Reference
 
-### `createPaseoClient(baseUrl: string)`
+### `createPaseoClient(baseUrl?: string)`
 
-Returns an SDK instance for communicating with a Paseo pod.
+Creates a new pod on the Paseo service and returns a client for interacting with it.
+
+### `client.podName`
+
+The ID of the pod created during initialization.
 
 ### `.usePod(id: string)`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export interface PaseoClient {
+  podName?: string;
   usePod(id: string): void;
   sendPrompt(prompt: string): Promise<string>;
   getConversation(): Promise<any[]>;
@@ -6,8 +7,16 @@ export interface PaseoClient {
   get(key: string): Promise<string | null>;
 }
 
-export function createPaseoClient(baseUrl: string): PaseoClient {
-  let podId: string | null = null;
+export async function createPaseoClient(
+  baseUrl = "https://paseo-core.paseo.workers.dev"
+): Promise<PaseoClient> {
+  const createRes = await fetch(`${baseUrl}/pods`, { method: "POST" });
+  if (!createRes.ok) {
+    throw new Error(`Failed to create pod: ${createRes.status}`);
+  }
+  const { podName } = await createRes.json();
+
+  let podId: string | null = podName;
 
   const ensurePod = () => {
     if (!podId) throw new Error("No pod selected. Call usePod(podId) first.");
@@ -15,6 +24,7 @@ export function createPaseoClient(baseUrl: string): PaseoClient {
   };
 
   return {
+    podName,
     usePod(id: string) {
       podId = id;
     },

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -6,19 +6,14 @@ dotenv.config();
 
 async function run() {
   try {
-    // Automatically create the client and pod
     const paseo = await createPaseoClient();
+    console.log(`🚀 Created pod: ${paseo.podName}`);
 
-    // Use the created pod (it will be automatically created)
-    paseo.usePod(paseo.podName || "dev-test");
-
-    // Send a prompt and log the response
     const reply = await paseo.sendPrompt("What is Paseo?");
-    console.log("🤖 LLM Response:", reply);
+    console.log(`🤖 (${paseo.podName})`, reply);
 
-    // Retrieve and log the conversation
     const convo = await paseo.getConversation();
-    console.log("🧠 Conversation:", convo);
+    console.log(`🧠 (${paseo.podName})`, convo);
   } catch (err) {
     console.error("❌ Test failed:", err);
   }


### PR DESCRIPTION
## Summary
- automatically create pods by calling paseo-core from `createPaseoClient`
- expose created pod name on the client
- update README quickstart and API docs
- refactor test script to show the pod name with results

## Testing
- `npm run build` *(fails: tsup not found)*
- `node test/test.mjs` *(fails: cannot find module '/workspace/paseo-sdk/dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6876d1bb635c83228dc7e1cc67794c78